### PR TITLE
Fix requirements

### DIFF
--- a/BE/requirements.txt
+++ b/BE/requirements.txt
@@ -2,7 +2,7 @@ validators
 redis
 jsonschema
 uuid
-flask_jwt_extended
+flask_jwt_extended==3.25.1
 flask_restful
 datetime
 passlib
@@ -10,3 +10,5 @@ sqlalchemy
 flask
 psycopg2
 flask_cors
+dnslib
+Flask-SQLAlchemy

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ You also should not forget to change all passwords and keys inside the config
 
 
 ```
+# First edit config.yaml as you please
+# Don't forget to change the JWT secret!
+vim config.yaml
+
 #Set up postgres and redis
 sudo docker-compose up
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ vim config.yaml
 #Set up postgres and redis
 sudo docker-compose up
 
+# Install python
+apt install docker-compose python3-pip
+sudo apt-get install libpq-dev python-dev
+
 #in ./BE
 pip3 install -r requirements.txt
 
@@ -51,6 +55,10 @@ python3 dns.py # to start the dns server
 FLASK_APP=app.py
 FLASK_ENV=development
 flask run
+
+# Install npm
+curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -       
+apt -y install nodejs make gcc g++
 
 # then in ./FE
 npm install

--- a/config.yaml
+++ b/config.yaml
@@ -7,7 +7,7 @@ sql:
         deprec_warn: false
 
 jwt:
-        secret_key: 'U(RH*3y328u$#ibf*YGRIBFJ)IHF(**^#@&!)'
+        secret_key: 'changeme'
         blacklist_enabled: true
         blacklist_token_checks: ['access']
         token_expires: 21600 # 6 hours


### PR DESCRIPTION
 - force flask_jwt_extended==3.25.1 because 4.0.0 doesn't work properly
 - add more requirements
 - change misleading example jwt secret_key
 - tell people to edit config in "How to run"